### PR TITLE
fix typo: master branch URL should be main

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,7 +402,7 @@ var mappingTableLabels = {
 		</section>
 		<section class="appendix" id="changelog">
 			<h2>Change Log</h2>
-			<p>The full <a href="https://github.com/w3c/graphics-aam/commits/master/index.html">commit history to Graphics Accessibility API Mappings 1.0</a> is available.</p>
+			<p>The full <a href="https://github.com/w3c/graphics-aam/commits/main/index.html">commit history to Graphics Accessibility API Mappings 1.0</a> is available.</p>
 			<!--<section>
 				<h2>Substantive changes since the <a href="@@">last public working draft</a></h2>
 				<ul>


### PR DESCRIPTION
fix typo: master branch URL should be main