### PR TITLE
Tries gh-contributors from respec

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,6 +423,8 @@ var mappingTableLabels = {
 		<section class="appendix informative section" id="acknowledgements">
 			<h3>Acknowledgments</h3>
 			<p>The following people contributed to the development of this document.</p>
+      <ul id="gh-contributors">
+      </ul>
 			<section class="section" id="ack_svga11y">
 				<h4>Participants active in the SVG accessibility task force at the time of publication</h4>
 				<ul>


### PR DESCRIPTION
This is just to show how gh-contributors from Respec works. It can:

* create an alphabetically ordered list of GitHub contributors with links to their GitHub profiles
* Create a comma-separated list of GitHub contributors, if we put `id="gh-contributors'` on an element different than `ul`

This is the GitHub doc where they explain what counts as a contribution
https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/managing-contribution-settings-on-your-profile/viewing-contributions-on-your-profile